### PR TITLE
name in galera metadata.rb

### DIFF
--- a/cookbooks/galera/metadata.rb
+++ b/cookbooks/galera/metadata.rb
@@ -1,3 +1,4 @@
+name             "galera"
 maintainer       "Severalnines AB"
 maintainer_email "support@severalnines.com"
 license          "Apache 2.0"


### PR DESCRIPTION
Adding name to the galera cookbook metadata.rb. This allows better integration with other tools like spiceweasel.